### PR TITLE
Feature/fixed string

### DIFF
--- a/grin.py
+++ b/grin.py
@@ -774,6 +774,8 @@ def get_grin_arg_parser(parser=None):
         help="show program's version number and exit")
     parser.add_argument('-i', '--ignore-case', action='append_const',
         dest='re_flags', const=re.I, default=[], help="ignore case in the regex")
+    parser.add_argument('-F', '--fixed-string', action='store_true',
+        dest='fixed_string', default=False, help='search pattern is fixed string, not regex')
     parser.add_argument('-A', '--after-context', default=0, type=int,
         help="the number of lines of context to show after the match [default=%(default)r]")
     parser.add_argument('-B', '--before-context', default=0, type=int,
@@ -1018,6 +1020,8 @@ def get_regex(args):
     flags = 0
     for flag in args.re_flags:
         flags |= flag
+    if args.fixed_string:
+        args.regex = re.escape(args.regex)
     return re.compile(args.regex, flags)
 
 

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -110,11 +110,14 @@ Test the basic defaults, no context.
     >>> # If fixed_string isn't set, the unbalanced paren should throw exception
     >>> args.fixed_string = False
     >>> args.regex = 'foo('
+    >>> failed = False
     >>> try:
     ...     regex = grin.get_regex(args)
     ... except Exception as e:
-    ...     str(e)
-    'unbalanced parenthesis'
+    ...     failed = True
+    ...
+    >>> str(failed)
+    'True'
 
 
 Symmetric 1-line context.

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -6,6 +6,7 @@ Set up
     >>> import grin
     >>> from io import BytesIO
     >>> import re
+    >>> import collections
     >>>
     >>> all_foo = b"""\
     ... foo
@@ -66,6 +67,16 @@ Set up
     ... bar
     ... bar
     ... """
+    >>> regex_metachar_foo = b"""\
+    ... bar
+    ... bar
+    ... def foo(...):
+    ... bar
+    ... foo
+    ... bar
+    ... bar
+    ... """
+
 
 Test the basic defaults, no context.
 
@@ -88,6 +99,24 @@ Test the basic defaults, no context.
     [(0, 0, 'foo', [(0, 3)])]
     >>> gt_default.do_grep(BytesIO(middle_of_line))
     [(2, 0, 'barfoobar\n', [(3, 6)])]
+    >>> # Fixed string support
+    >>> class args:
+    ...     re_flags = []
+    ...     regex = 'foo('
+    ...     fixed_string = True
+    >>> regex = grin.get_regex(args)
+    >>> gt_fixedstring_match = grin.GrepText(regex)
+    >>> gt_fixedstring_match.do_grep(BytesIO(regex_metachar_foo))
+    [(2, 0, 'def foo(...):\n', [(4, 8)])]
+    >>> # If fixed_string isn't set, the unbalanced paren should throw exception
+    >>> args.fixed_string = False
+    >>> args.regex = 'foo('
+    >>> try:
+    ...     regex = grin.get_regex(args)
+    ... except Exception as e:
+    ...     print e
+    unbalanced parenthesis
+
 
 Symmetric 1-line context.
 

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -6,7 +6,6 @@ Set up
     >>> import grin
     >>> from io import BytesIO
     >>> import re
-    >>> import collections
     >>>
     >>> all_foo = b"""\
     ... foo

--- a/tests/test_grep.py
+++ b/tests/test_grep.py
@@ -113,8 +113,8 @@ Test the basic defaults, no context.
     >>> try:
     ...     regex = grin.get_regex(args)
     ... except Exception as e:
-    ...     print e
-    unbalanced parenthesis
+    ...     str(e)
+    'unbalanced parenthesis'
 
 
 Symmetric 1-line context.


### PR DESCRIPTION
Similar to GNU's grep -F, this adds the -F/--fixed-string option, which saves you having to manually escape regex metachars when you just want to search for a plain string.

I find this handy when searching for function definitions or calls, being able to `grin 'foo('` instead of having to `grin 'foo\('` all the time.